### PR TITLE
Git Ignore Addressing Temp Files and removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,61 @@
-﻿
-# Directories to ignore
-SherbertEngine/imgui.ini
+﻿# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
 
-# Build Result Outputs
-SherbertEngine/x64
-*.exe
-*.log
-*.tlog
-*.pdb
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs
+
+# Mono auto generated files
+mono_crash.*
+
+# Build results Outputs
+# Remove Debug - Release Folders
+# Remove x64 and x86 folders
+Build/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Ll]og/
+[Ll]ogs/
 
 # Visual Studio bullshittery
 .vs
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+*.exe
+*.pdb
+*.ilk
 *.aps
+*.ipch
+*.log
+*.tlog
+*.ncb
+*.opendb
+*.sdf
+*.dbmdl
+*.sqlite
+*.VC.opendb
+*.VC.db
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.pch
+*.mdmp
+*.exp
+
+# Ignore specific file types in all folders
+*.res
+*.exe
+*.exe.recipe
 
 # Imgui ini
-SherbertEngine/imgui.ini
+
 SherbertEngine/log.txt
+SherbertEngine/imgui.ini


### PR DESCRIPTION
The following Git ignore addressed Temporary Visual studio files and folder and files generated that are not specifically required for the engine, and are instead made by the Engine's Build.

NOTE:

The following Requires all other PR's to address this gitIgnore Change, meaning that any Folder remaining currently should be removed, otherwise they will stay on the branch, though any further changes will be removed as they are generated.